### PR TITLE
feat: adds README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,101 @@
-# android
-Formbricks Android SDK
+# Formbricks Android SDK
+
+**Formbricks Android SDK** provides an easy way to embed Formbricks surveys and feedback forms in your Android applications via a WebView or Fragment. It handles survey loading, analytics tracking, and secure communication with your Formbricks server.
+
+---
+
+## Features
+
+- Full-screen survey support via a dedicated `Activity`.
+- Embedded survey support via a `Fragment` with `ViewBinding`.
+- Automatic JavaScript configuration and WebViewClient handling.
+- Optional analytics tracking integration.
+- Easy setup with Gradle and Maven Central.
+
+---
+
+## Installation
+
+Add the Maven Central repository and the Formbricks SDK dependency to your application's `build.gradle.kts`:
+
+```kotlin
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.formbricks.android:android:0.1.0") // replace with latest version
+}
+Enable ViewBinding (and DataBinding if needed) in your app’s module build.gradle.kts:
+
+kotlin
+Copy
+Edit
+android {
+  buildFeatures {
+    viewBinding = true
+    // dataBinding = true  // only if your own layouts use DataBinding
+  }
+}
+Usage
+1. Initialize the SDK
+In your Activity’s onCreate, configure and initialize Formbricks. You must supply the host’s supportFragmentManager:
+
+kotlin
+Copy
+Edit
+val config = FormbricksConfig.Builder(
+    "https://your-formbricks-server.com",
+    "YOUR_ENVIRONMENT_ID"
+)
+  .setLoggingEnabled(true)
+  .setFragmentManager(supportFragmentManager)
+  .build()
+
+Formbricks.setup(this, config, true)
+Formbricks.setUserId("user-12345")
+2. Open (trigger) a survey
+To display a survey, simply call Formbricks.track(...) with your survey URL. The SDK will handle launching its WebView internally:
+
+kotlin
+Copy
+Edit
+Formbricks.track(
+    event = "survey",
+    properties = mapOf("url" to "https://your-formbricks-server.com/survey/abc123")
+)
+This will open the survey in the SDK’s built-in WebView.
+
+3. Track Custom Events
+You can also log arbitrary analytics events without UI:
+
+kotlin
+Copy
+Edit
+Formbricks.track("button_clicked")
+Configuration Options
+
+Option	Description
+setLoggingEnabled(...)	Enable verbose SDK logs for debugging
+setFragmentManager(...)	Required if you embed via Fragment
+setUserId(...)	Identify app users for analytics
+The full FormbricksConfig.Builder API provides additional hooks for customizing headers, timeouts, and callbacks.
+
+ProGuard / R8
+If you use ProGuard or R8, the SDK includes a consumer-rules.pro that keeps required DataBinding classes. Ensure your app’s build.gradle references it:
+
+kotlin
+Copy
+Edit
+android {
+  defaultConfig {
+    consumerProguardFiles("consumer-rules.pro")
+  }
+}
+Contributing
+We welcome issues and pull requests on our GitHub repository.
+
+License
+This SDK is released under the MIT License.
+```

--- a/README.md
+++ b/README.md
@@ -27,24 +27,25 @@ repositories {
 dependencies {
     implementation("com.formbricks.android:android:0.1.0") // replace with latest version
 }
+```
+
 Enable ViewBinding (and DataBinding if needed) in your app’s module build.gradle.kts:
 
-kotlin
-Copy
-Edit
+```kotlin
 android {
   buildFeatures {
     viewBinding = true
     // dataBinding = true  // only if your own layouts use DataBinding
   }
 }
-Usage
-1. Initialize the SDK
-In your Activity’s onCreate, configure and initialize Formbricks. You must supply the host’s supportFragmentManager:
+```
 
-kotlin
-Copy
-Edit
+## Usage
+
+1. Initialize the SDK
+   In your Activity’s onCreate, configure and initialize Formbricks. You must supply the host’s supportFragmentManager:
+
+```kotlin
 val config = FormbricksConfig.Builder(
     "https://your-formbricks-server.com",
     "YOUR_ENVIRONMENT_ID"
@@ -55,47 +56,31 @@ val config = FormbricksConfig.Builder(
 
 Formbricks.setup(this, config, true)
 Formbricks.setUserId("user-12345")
-2. Open (trigger) a survey
-To display a survey, simply call Formbricks.track(...) with your survey URL. The SDK will handle launching its WebView internally:
+```
 
-kotlin
-Copy
-Edit
+2. Open (trigger) a survey
+   To display a survey, simply call Formbricks.track(...) with your survey URL. The SDK will handle launching its WebView internally:
+
+```kotlin
 Formbricks.track(
     event = "survey",
     properties = mapOf("url" to "https://your-formbricks-server.com/survey/abc123")
 )
+```
+
 This will open the survey in the SDK’s built-in WebView.
 
 3. Track Custom Events
-You can also log arbitrary analytics events without UI:
+   You can also log arbitrary analytics events without UI:
 
-kotlin
-Copy
-Edit
+```kotlin
 Formbricks.track("button_clicked")
-Configuration Options
+```
 
-Option	Description
-setLoggingEnabled(...)	Enable verbose SDK logs for debugging
-setFragmentManager(...)	Required if you embed via Fragment
-setUserId(...)	Identify app users for analytics
-The full FormbricksConfig.Builder API provides additional hooks for customizing headers, timeouts, and callbacks.
+## Contributing
 
-ProGuard / R8
-If you use ProGuard or R8, the SDK includes a consumer-rules.pro that keeps required DataBinding classes. Ensure your app’s build.gradle references it:
-
-kotlin
-Copy
-Edit
-android {
-  defaultConfig {
-    consumerProguardFiles("consumer-rules.pro")
-  }
-}
-Contributing
 We welcome issues and pull requests on our GitHub repository.
 
-License
+## License
+
 This SDK is released under the MIT License.
-```

--- a/README.md
+++ b/README.md
@@ -1,18 +1,6 @@
 # Formbricks Android SDK
 
-**Formbricks Android SDK** provides an easy way to embed Formbricks surveys and feedback forms in your Android applications via a WebView or Fragment. It handles survey loading, analytics tracking, and secure communication with your Formbricks server.
-
----
-
-## Features
-
-- Full-screen survey support via a dedicated `Activity`.
-- Embedded survey support via a `Fragment` with `ViewBinding`.
-- Automatic JavaScript configuration and WebViewClient handling.
-- Optional analytics tracking integration.
-- Easy setup with Gradle and Maven Central.
-
----
+**Formbricks Android SDK** provides an easy way to embed Formbricks surveys and feedback forms in your Android applications via a WebView.
 
 ## Installation
 
@@ -25,27 +13,24 @@ repositories {
 }
 
 dependencies {
-    implementation("com.formbricks.android:android:0.1.0") // replace with latest version
+    implementation("com.formbricks.android:android:1.0.0") // replace with latest version
 }
 ```
 
-Enable ViewBinding (and DataBinding if needed) in your app’s module build.gradle.kts:
+Enable DataBinding in your app’s module build.gradle.kts:
 
 ```kotlin
 android {
   buildFeatures {
-    viewBinding = true
-    // dataBinding = true  // only if your own layouts use DataBinding
+    dataBinding = true
   }
 }
 ```
 
 ## Usage
 
-1. Initialize the SDK
-   In your Activity’s onCreate, configure and initialize Formbricks. You must supply the host’s supportFragmentManager:
-
 ```kotlin
+// 1. Initialize the SDK
 val config = FormbricksConfig.Builder(
     "https://your-formbricks-server.com",
     "YOUR_ENVIRONMENT_ID"
@@ -54,27 +39,24 @@ val config = FormbricksConfig.Builder(
   .setFragmentManager(supportFragmentManager)
   .build()
 
-Formbricks.setup(this, config, true)
-Formbricks.setUserId("user-12345")
-```
+// 2. Setup Formbricks
+Formbricks.setup(this, config)
 
-2. Open (trigger) a survey
-   To display a survey, simply call Formbricks.track(...) with your survey URL. The SDK will handle launching its WebView internally:
+// 3. Identify the user
+Formbricks.setUserId("user‑123")
 
-```kotlin
-Formbricks.track(
-    event = "survey",
-    properties = mapOf("url" to "https://your-formbricks-server.com/survey/abc123")
-)
-```
+// 4. Track events
+Formbricks.track("button_pressed")
 
-This will open the survey in the SDK’s built-in WebView.
+// 5. Set or add user attributes
+Formbricks.setAttribute("test@web.com", "email")
+Formbricks.setAttributes(mapOf(Pair("attr1", "val1"), Pair("attr2", "val2")))
 
-3. Track Custom Events
-   You can also log arbitrary analytics events without UI:
+// 6. Change language (no userId required):
+Formbricks.setLanguage("de")
 
-```kotlin
-Formbricks.track("button_clicked")
+// 7. Log out:
+Formbricks.logout()
 ```
 
 ## Contributing


### PR DESCRIPTION
This pull request updates the `README.md` file to provide comprehensive documentation for the Formbricks Android SDK. The changes include a detailed installation guide, usage examples, and additional sections for contributing and licensing.

### Documentation Enhancements:

* Updated the title and added an introductory description of the Formbricks Android SDK, explaining its purpose and functionality.
* Added an installation guide with instructions for adding the Maven Central repository, SDK dependency, and enabling DataBinding in the `build.gradle.kts` file.
* Included a detailed usage section with code examples for initializing the SDK, setting up Formbricks, identifying users, tracking events, managing user attributes, changing the language, and logging out.
* Added new sections for contributing guidelines and licensing information, encouraging community involvement and clarifying usage terms.