### PR TITLE
fix: remove callbacks and fixes segment issue

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("com.vanniktech.maven.publish") version "0.31.0"
 }
 
-version = "1.0.0"
+version = "1.1.0"
 val groupId = "com.formbricks"
 val artifactId = "android"
 

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -35,7 +35,6 @@
 -keep class com.formbricks.android.Formbricks { *; }
 -keep class com.formbricks.android.helper.FormbricksConfig { *; }
 -keep class com.formbricks.android.model.error.SDKError { *; }
--keep interface com.formbricks.android.FormbricksCallback { *; }
 
 # Keep StringConcatFactory and related classes
 -keep class java.lang.invoke.StringConcatFactory { *; }

--- a/android/src/main/java/com/formbricks/android/Formbricks.kt
+++ b/android/src/main/java/com/formbricks/android/Formbricks.kt
@@ -10,21 +10,9 @@ import com.formbricks.android.helper.FormbricksConfig
 import com.formbricks.android.logger.Logger
 import com.formbricks.android.manager.SurveyManager
 import com.formbricks.android.manager.UserManager
-import com.formbricks.android.model.enums.SuccessType
 import com.formbricks.android.model.error.SDKError
 import com.formbricks.android.webview.FormbricksFragment
 import java.lang.RuntimeException
-
-@Keep
-interface FormbricksCallback {
-    fun onSurveyStarted()
-    fun onSurveyFinished()
-    fun onSurveyClosed()
-    fun onPageCommitVisible()
-    fun onError(error: Exception)
-    fun onSuccess(successType: SuccessType)
-}
-
 
 @Keep
 object Formbricks {
@@ -36,8 +24,6 @@ object Formbricks {
     internal var loggingEnabled: Boolean = true
     private var fragmentManager: FragmentManager? = null
     internal var isInitialized = false
-
-    var callback: FormbricksCallback? = null
 
     /**
      * Initializes the Formbricks SDK with the given [Context] config [FormbricksConfig].
@@ -62,7 +48,6 @@ object Formbricks {
     fun setup(context: Context, config: FormbricksConfig, forceRefresh: Boolean = false) {
         if (isInitialized && !forceRefresh) {
             val error = SDKError.sdkIsAlreadyInitialized
-            callback?.onError(error)
             Logger.e(error)
             return
         }
@@ -97,14 +82,12 @@ object Formbricks {
     fun setUserId(userId: String) {
         if (!isInitialized) {
             val error = SDKError.sdkIsNotInitialized
-            callback?.onError(error)
             Logger.e(error)
             return
         }
 
         if(UserManager.userId != null) {
             val error = RuntimeException("A userId is already set ${UserManager.userId} - please call logout first before setting a new one")
-            callback?.onError(error)
             Logger.e(error)
             return
         }
@@ -124,7 +107,6 @@ object Formbricks {
     fun setAttribute(attribute: String, key: String) {
         if (!isInitialized) {
             val error = SDKError.sdkIsNotInitialized
-            callback?.onError(error)
             Logger.e(error)
             return
         }
@@ -143,7 +125,6 @@ object Formbricks {
     fun setAttributes(attributes: Map<String, String>) {
         if (!isInitialized) {
             val error = SDKError.sdkIsNotInitialized
-            callback?.onError(error)
             Logger.e(error)
             return
         }
@@ -162,7 +143,6 @@ object Formbricks {
     fun setLanguage(language: String) {
         if (!isInitialized) {
             val error = SDKError.sdkIsNotInitialized
-            callback?.onError(error)
             Logger.e(error)
             return
         }
@@ -182,14 +162,12 @@ object Formbricks {
     fun track(action: String) {
         if (!isInitialized) {
             val error = SDKError.sdkIsNotInitialized
-            callback?.onError(error)
             Logger.e(error)
             return
         }
 
         if (!isInternetAvailable()) {
             val error = SDKError.connectionIsNotAvailable
-            callback?.onError(error)
             Logger.e(error)
             return
         }
@@ -209,12 +187,10 @@ object Formbricks {
     fun logout() {
         if (!isInitialized) {
             val error = SDKError.sdkIsNotInitialized
-            callback?.onError(error)
             Logger.e(error)
             return
         }
 
-        callback?.onSuccess(SuccessType.LOGOUT_SUCCESS)
         UserManager.logout()
     }
 
@@ -236,7 +212,6 @@ object Formbricks {
     internal fun showSurvey(id: String) {
         if (fragmentManager == null) {
             val error = SDKError.fragmentManagerIsNotSet
-            callback?.onError(error)
             Logger.e(error)
             return
         }

--- a/android/src/main/java/com/formbricks/android/manager/SurveyManager.kt
+++ b/android/src/main/java/com/formbricks/android/manager/SurveyManager.kt
@@ -9,7 +9,6 @@ import com.formbricks.android.logger.Logger
 import com.formbricks.android.model.environment.EnvironmentDataHolder
 import com.formbricks.android.model.environment.Survey
 import com.formbricks.android.model.error.SDKError
-import com.formbricks.android.model.enums.SuccessType
 import com.formbricks.android.model.user.Display
 import com.google.gson.Gson
 import kotlinx.coroutines.CoroutineScope
@@ -60,7 +59,6 @@ object SurveyManager {
                     try {
                         Gson().fromJson(json, EnvironmentDataHolder::class.java)
                     } catch (e: Exception) {
-                        Formbricks.callback?.onError(e)
                         Logger.e(RuntimeException("Unable to retrieve environment data from the local storage."))
                         null
                     }
@@ -118,11 +116,9 @@ object SurveyManager {
                 startRefreshTimer(environmentDataHolder?.expiresAt())
                 filterSurveys()
                 hasApiError = false
-                Formbricks.callback?.onSuccess(SuccessType.GET_ENVIRONMENT_SUCCESS)
             } catch (e: Exception) {
                 hasApiError = true
                 val error = SDKError.unableToRefreshEnvironment
-                Formbricks.callback?.onError(error)
                 Logger.e(error)
                 startErrorTimer()
             }
@@ -143,7 +139,8 @@ object SurveyManager {
         }
 
         if (firstSurveyWithActionClass == null) {
-            Formbricks.callback?.onError(SDKError.surveyNotFoundError)
+            val error = SDKError.surveyNotFoundError
+            Logger.e(error)
             return
         }
 
@@ -154,7 +151,6 @@ object SurveyManager {
 
             if (languageCode == null) {
                 val error = RuntimeException("Survey “${firstSurveyWithActionClass.name}” is not available in language “$currentLanguage”. Skipping.")
-                Formbricks.callback?.onError(error)
                 Logger.e(error)
                 return
             }
@@ -177,7 +173,8 @@ object SurveyManager {
                 }, Date(System.currentTimeMillis() + timeout.toLong() * 1000))
             }
         } else {
-           Formbricks.callback?.onError(SDKError.surveyNotDisplayedError)
+            val error = SDKError.surveyNotDisplayedError
+            Logger.e(error)
         }
     }
 
@@ -192,7 +189,6 @@ object SurveyManager {
     fun postResponse(surveyId: String?) {
         val id = surveyId.guard {
             val error = SDKError.missingSurveyId
-            Formbricks.callback?.onError(error)
             Logger.e(error)
             return
         }
@@ -206,7 +202,6 @@ object SurveyManager {
     fun onNewDisplay(surveyId: String?) {
         val id = surveyId.guard {
             val error = SDKError.missingSurveyId
-            Formbricks.callback?.onError(error)
             Logger.e(error)
             return
         }
@@ -269,7 +264,6 @@ object SurveyManager {
 
                 else -> {
                     val error = SDKError.invalidDisplayOption
-                    Formbricks.callback?.onError(error)
                     Logger.e(error)
                     false
                 }

--- a/android/src/main/java/com/formbricks/android/manager/UserManager.kt
+++ b/android/src/main/java/com/formbricks/android/manager/UserManager.kt
@@ -147,10 +147,8 @@ object UserManager {
                 UpdateQueue.current.reset()
                 SurveyManager.filterSurveys()
                 startSyncTimer()
-                Formbricks.callback?.onSuccess(SuccessType.SET_USER_SUCCESS)
             } catch (e: Exception) {
                 val error = SDKError.unableToPostResponse
-                Formbricks.callback?.onError(error)
                 Logger.e(error)
             }
         }
@@ -164,7 +162,6 @@ object UserManager {
 
         if (!isUserIdDefined) {
             val error = SDKError.noUserIdSetError
-            Formbricks.callback?.onError(error)
             Logger.e(error)
         }
 

--- a/android/src/main/java/com/formbricks/android/model/environment/EnvironmentData.kt
+++ b/android/src/main/java/com/formbricks/android/model/environment/EnvironmentData.kt
@@ -7,5 +7,6 @@ import kotlinx.serialization.Serializable
 data class EnvironmentData(
     @SerializedName("surveys") val surveys: List<Survey>?,
     @SerializedName("actionClasses") val actionClasses: List<ActionClass>?,
-    @SerializedName("project") val project: Project
+    @SerializedName("project") val project: Project,
+    @SerializedName("recaptchaSiteKey") val recaptchaSiteKey: String?
 )

--- a/android/src/main/java/com/formbricks/android/model/environment/Segment.kt
+++ b/android/src/main/java/com/formbricks/android/model/environment/Segment.kt
@@ -1,17 +1,183 @@
 package com.formbricks.android.model.environment
 
-import com.google.gson.annotations.SerializedName
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.*
+import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.encoding.*
 
+// MARK: - Connector
+@Serializable
+enum class SegmentConnector {
+    @SerialName("and") AND,
+    @SerialName("or") OR
+}
+
+// MARK: - Filter Operators
+@Serializable
+enum class FilterOperator {
+    @SerialName("lessThan") LESS_THAN,
+    @SerialName("lessEqual") LESS_EQUAL,
+    @SerialName("greaterThan") GREATER_THAN,
+    @SerialName("greaterEqual") GREATER_EQUAL,
+    @SerialName("equals") EQUALS,
+    @SerialName("notEquals") NOT_EQUALS,
+    @SerialName("contains") CONTAINS,
+    @SerialName("doesNotContain") DOES_NOT_CONTAIN,
+    @SerialName("startsWith") STARTS_WITH,
+    @SerialName("endsWith") ENDS_WITH,
+    @SerialName("isSet") IS_SET,
+    @SerialName("isNotSet") IS_NOT_SET,
+    @SerialName("userIsIn") USER_IS_IN,
+    @SerialName("userIsNotIn") USER_IS_NOT_IN
+}
+
+// MARK: - Filter Value
+@Serializable(with = SegmentFilterValueSerializer::class)
+sealed class SegmentFilterValue {
+    data class StringValue(val value: String) : SegmentFilterValue()
+    data class NumberValue(val value: Double) : SegmentFilterValue()
+}
+
+object SegmentFilterValueSerializer : KSerializer<SegmentFilterValue> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("SegmentFilterValue", PrimitiveKind.STRING)
+    override fun deserialize(decoder: Decoder): SegmentFilterValue {
+        val jsonInput = decoder as JsonDecoder
+        val element = jsonInput.decodeJsonElement()
+        return when (element) {
+            is JsonPrimitive -> {
+                element.doubleOrNull?.let { SegmentFilterValue.NumberValue(it) }
+                    ?: SegmentFilterValue.StringValue(element.content)
+            }
+            else -> throw SerializationException("Unexpected type for SegmentFilterValue: $element")
+        }
+    }
+    override fun serialize(encoder: Encoder, value: SegmentFilterValue) {
+        val jsonOutput = encoder as JsonEncoder
+        val element = when (value) {
+            is SegmentFilterValue.NumberValue -> JsonPrimitive(value.value)
+            is SegmentFilterValue.StringValue -> JsonPrimitive(value.value)
+        }
+        jsonOutput.encodeJsonElement(element)
+    }
+}
+
+// MARK: - Filter Root
+@Serializable(with = SegmentFilterRootSerializer::class)
+sealed class SegmentFilterRoot {
+    data class Attribute(val contactAttributeKey: String) : SegmentFilterRoot()
+    data class Person(val personIdentifier: String) : SegmentFilterRoot()
+    data class Segment(val segmentId: String) : SegmentFilterRoot()
+    data class Device(val deviceType: String) : SegmentFilterRoot()
+}
+
+object SegmentFilterRootSerializer : KSerializer<SegmentFilterRoot> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("SegmentFilterRoot") {
+        element<String>("type")
+    }
+    override fun deserialize(decoder: Decoder): SegmentFilterRoot {
+        val input = decoder as JsonDecoder
+        val obj = input.decodeJsonElement().jsonObject
+        return when (val type = obj["type"]?.jsonPrimitive?.content) {
+            "attribute" -> SegmentFilterRoot.Attribute(obj["contactAttributeKey"]!!.jsonPrimitive.content)
+            "person"    -> SegmentFilterRoot.Person(obj["personIdentifier"]!!.jsonPrimitive.content)
+            "segment"   -> SegmentFilterRoot.Segment(obj["segmentId"]!!.jsonPrimitive.content)
+            "device"    -> SegmentFilterRoot.Device(obj["deviceType"]!!.jsonPrimitive.content)
+            else         -> throw SerializationException("Unknown root type: $type")
+        }
+    }
+    override fun serialize(encoder: Encoder, value: SegmentFilterRoot) {
+        val output = encoder as JsonEncoder
+        val json = buildJsonObject {
+            when (value) {
+                is SegmentFilterRoot.Attribute -> {
+                    put("type", JsonPrimitive("attribute"))
+                    put("contactAttributeKey", JsonPrimitive(value.contactAttributeKey))
+                }
+                is SegmentFilterRoot.Person -> {
+                    put("type", JsonPrimitive("person"))
+                    put("personIdentifier", JsonPrimitive(value.personIdentifier))
+                }
+                is SegmentFilterRoot.Segment -> {
+                    put("type", JsonPrimitive("segment"))
+                    put("segmentId", JsonPrimitive(value.segmentId))
+                }
+                is SegmentFilterRoot.Device -> {
+                    put("type", JsonPrimitive("device"))
+                    put("deviceType", JsonPrimitive(value.deviceType))
+                }
+            }
+        }
+        output.encodeJsonElement(json)
+    }
+}
+
+// MARK: - Qualifier
+@Serializable
+data class SegmentFilterQualifier(
+    @SerialName("operator") val `operator`: FilterOperator
+)
+
+// MARK: - Primitive Filter
+@Serializable
+data class SegmentPrimitiveFilter(
+    val id: String,
+    val root: SegmentFilterRoot,
+    val value: SegmentFilterValue,
+    val qualifier: SegmentFilterQualifier
+)
+
+// MARK: - Recursive Resource
+@Serializable(with = SegmentFilterResourceSerializer::class)
+sealed class SegmentFilterResource {
+    data class Primitive(val filter: SegmentPrimitiveFilter) : SegmentFilterResource()
+    data class Group(val filters: List<SegmentFilter>) : SegmentFilterResource()
+}
+
+object SegmentFilterResourceSerializer : KSerializer<SegmentFilterResource> {
+    override val descriptor = buildClassSerialDescriptor("SegmentFilterResource") {
+        // You can declare children here if you like,
+        // or leave it empty if you’re purely passing through.
+    }
+    override fun deserialize(decoder: Decoder): SegmentFilterResource {
+        val input = decoder as JsonDecoder
+        val element = input.decodeJsonElement()
+        return if (element is JsonArray) {
+            val list = element.map { input.json.decodeFromJsonElement(SegmentFilter.serializer(), it) }
+            SegmentFilterResource.Group(list)
+        } else {
+            val prim = input.json.decodeFromJsonElement(SegmentPrimitiveFilter.serializer(), element)
+            SegmentFilterResource.Primitive(prim)
+        }
+    }
+    override fun serialize(encoder: Encoder, value: SegmentFilterResource) {
+        val output = encoder as JsonEncoder
+        val json = when (value) {
+            is SegmentFilterResource.Primitive -> output.json.encodeToJsonElement(SegmentPrimitiveFilter.serializer(), value.filter)
+            is SegmentFilterResource.Group     -> output.json.encodeToJsonElement(ListSerializer(SegmentFilter.serializer()), value.filters)
+        }
+        output.encodeJsonElement(json)
+    }
+}
+
+// MARK: - Filter Node
+@Serializable
+data class SegmentFilter(
+    val id: String,
+    val connector: SegmentConnector? = null,
+    val resource: SegmentFilterResource
+)
+
+// MARK: - Segment Model
 @Serializable
 data class Segment(
-    @SerializedName("id") val id: String? = null,
-    @SerializedName("createdAt") val createdAt: String? = null,
-    @SerializedName("updatedAt") val updatedAt: String? = null,
-    @SerializedName("title") val title: String? = null,
-    @SerializedName("description") val description: String? = null,
-    @SerializedName("isPrivate") val isPrivate: Boolean? = null,
-    @SerializedName("filters") val filters: List<String>? = null,
-    @SerializedName("environmentId") val environmentId: String? = null,
-    @SerializedName("surveys") val surveys: List<String>? = null
+    val id: String,
+    val title: String,
+    val description: String? = null,
+    @SerialName("isPrivate") val isPrivate: Boolean,
+    val filters: List<SegmentFilter>,
+    val environmentId: String,
+    val createdAt: String,
+    val updatedAt: String,
+    val surveys: List<String>
 )

--- a/android/src/main/java/com/formbricks/android/model/environment/Survey.kt
+++ b/android/src/main/java/com/formbricks/android/model/environment/Survey.kt
@@ -30,5 +30,5 @@ data class Survey(
     @SerializedName("displayOption") val displayOption: String?,
     @SerializedName("segment") val segment: Segment?,
     @SerializedName("styling") val styling: Styling?,
-    @SerializedName("languages") val languages: List<SurveyLanguage>?
+    @SerializedName("languages") val languages: List<SurveyLanguage>?,
 )

--- a/android/src/main/java/com/formbricks/android/network/queue/UpdateQueue.kt
+++ b/android/src/main/java/com/formbricks/android/network/queue/UpdateQueue.kt
@@ -1,6 +1,5 @@
 package com.formbricks.android.network.queue
 
-import com.formbricks.android.Formbricks
 import com.formbricks.android.logger.Logger
 import com.formbricks.android.manager.UserManager
 import com.formbricks.android.model.error.SDKError
@@ -68,7 +67,6 @@ class UpdateQueue private constructor() {
             ?: UserManager.userId
         if (effectiveUserId == null) {
             val error = SDKError.noUserIdSetError
-            Formbricks.callback?.onError(error)
             Logger.e(error)
             return
         }

--- a/android/src/main/java/com/formbricks/android/webview/FormbricksFragment.kt
+++ b/android/src/main/java/com/formbricks/android/webview/FormbricksFragment.kt
@@ -25,7 +25,6 @@ import android.widget.FrameLayout
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
-import com.formbricks.android.Formbricks
 import com.formbricks.android.R
 import com.formbricks.android.databinding.FragmentFormbricksBinding
 import com.formbricks.android.logger.Logger
@@ -37,26 +36,22 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.gson.JsonObject
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
-import java.util.Timer
 
 
 class FormbricksFragment : BottomSheetDialogFragment() {
 
     private lateinit var binding: FragmentFormbricksBinding
     private lateinit var surveyId: String
-    private val closeTimer = Timer()
     private val viewModel: FormbricksViewModel by viewModels()
 
     private var webAppInterface = WebAppInterface(object : WebAppInterface.WebAppCallback {
         override fun onClose() {
             Handler(Looper.getMainLooper()).post {
-                Formbricks.callback?.onSurveyClosed()
                 dismiss()
             }
         }
 
         override fun onDisplayCreated() {
-            Formbricks.callback?.onSurveyStarted()
             SurveyManager.onNewDisplay(surveyId)
         }
 
@@ -74,7 +69,8 @@ class FormbricksFragment : BottomSheetDialogFragment() {
         }
 
         override fun onSurveyLibraryLoadError() {
-            Formbricks.callback?.onError(SDKError.unableToLoadFormbicksJs)
+            val error = SDKError.unableToLoadFormbicksJs
+            Logger.e(error)
             dismiss()
         }
     })
@@ -155,7 +151,8 @@ class FormbricksFragment : BottomSheetDialogFragment() {
                 override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
                     consoleMessage?.let { cm ->
                         if (cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) {
-                            Formbricks.callback?.onError(SDKError.surveyDisplayFetchError)
+                            val error = SDKError.surveyDisplayFetchError
+                            Logger.e(error)
                             dismiss()
                         }
                         val log = "[CONSOLE:${cm.messageLevel()}] \"${cm.message()}\", source: ${cm.sourceId()} (${cm.lineNumber()})"

--- a/android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt
+++ b/android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt
@@ -99,7 +99,7 @@ class FormbricksViewModel : ViewModel() {
               observer.observe(document.body, { childList: true, subtree: true });
 
                 const script = document.createElement("script");
-                script.src = "${Formbricks.appUrl}/js/surveys.umd.cjs";
+                script.src = "${Formbricks.appUrl}/js/surveys.umd.cjs?randQuery=123445";
                 script.async = true;
                 script.onload = () => loadSurvey();
                 script.onerror = (error) => {

--- a/android/src/main/java/com/formbricks/android/webview/WebAppInterface.kt
+++ b/android/src/main/java/com/formbricks/android/webview/WebAppInterface.kt
@@ -1,7 +1,6 @@
 package com.formbricks.android.webview
 
 import android.webkit.JavascriptInterface
-import com.formbricks.android.Formbricks
 import com.formbricks.android.logger.Logger
 import com.formbricks.android.model.javascript.JsMessageData
 import com.formbricks.android.model.javascript.EventType
@@ -36,15 +35,12 @@ class WebAppInterface(private val callback: WebAppCallback?) {
                 EventType.ON_SURVEY_LIBRARY_LOAD_ERROR -> { callback?.onSurveyLibraryLoadError() }
             }
         } catch (e: Exception) {
-            Formbricks.callback?.onError(e)
             Logger.e(RuntimeException(e.message))
         } catch (e: JsonParseException) {
             Logger.e(RuntimeException("Failed to parse JSON message: $data"))
         } catch (e: IllegalArgumentException) {
-            Formbricks.callback?.onError(e)
             Logger.e(RuntimeException("Invalid message format: $data"))
         } catch (e: Exception) {
-            Formbricks.callback?.onError(e)
             Logger.e(RuntimeException("Unexpected error processing message: $data"))
         }
     }


### PR DESCRIPTION
This pull request includes several changes to the Formbricks Android SDK, primarily focused on removing the `FormbricksCallback` interface, simplifying error handling, and introducing a new field in the `EnvironmentData` model. Below is a summary of the most important changes:

### Version Update
* Updated the SDK version from `1.0.0` to `1.1.0` in `android/build.gradle.kts` to reflect the changes in functionality.

### Callback Removal
* Removed the `FormbricksCallback` interface and its associated methods from `Formbricks.kt`, as well as all references to `callback` throughout the SDK. Error handling now directly logs errors using the `Logger` class instead of invoking callback methods. [[1]](diffhunk://#diff-82c6e97a2d17fd4a1ad9d7d6189b0f8bcb6ed3b122e085bbe02ec8cdbbe60376L13-L28) [[2]](diffhunk://#diff-82c6e97a2d17fd4a1ad9d7d6189b0f8bcb6ed3b122e085bbe02ec8cdbbe60376L40-L41) [[3]](diffhunk://#diff-82c6e97a2d17fd4a1ad9d7d6189b0f8bcb6ed3b122e085bbe02ec8cdbbe60376L65) [[4]](diffhunk://#diff-82c6e97a2d17fd4a1ad9d7d6189b0f8bcb6ed3b122e085bbe02ec8cdbbe60376L100-L107) [[5]](diffhunk://#diff-82c6e97a2d17fd4a1ad9d7d6189b0f8bcb6ed3b122e085bbe02ec8cdbbe60376L127) [[6]](diffhunk://#diff-82c6e97a2d17fd4a1ad9d7d6189b0f8bcb6ed3b122e085bbe02ec8cdbbe60376L146) [[7]](diffhunk://#diff-82c6e97a2d17fd4a1ad9d7d6189b0f8bcb6ed3b122e085bbe02ec8cdbbe60376L165) [[8]](diffhunk://#diff-82c6e97a2d17fd4a1ad9d7d6189b0f8bcb6ed3b122e085bbe02ec8cdbbe60376L185-L192) [[9]](diffhunk://#diff-82c6e97a2d17fd4a1ad9d7d6189b0f8bcb6ed3b122e085bbe02ec8cdbbe60376L212-L217) [[10]](diffhunk://#diff-82c6e97a2d17fd4a1ad9d7d6189b0f8bcb6ed3b122e085bbe02ec8cdbbe60376L239) [[11]](diffhunk://#diff-bde2d5dbfa308a53395144d54ecc66f60c7665cf2b93c72e33221ae025969f60L63) [[12]](diffhunk://#diff-bde2d5dbfa308a53395144d54ecc66f60c7665cf2b93c72e33221ae025969f60L121-L125) [[13]](diffhunk://#diff-bde2d5dbfa308a53395144d54ecc66f60c7665cf2b93c72e33221ae025969f60L146-R143) [[14]](diffhunk://#diff-bde2d5dbfa308a53395144d54ecc66f60c7665cf2b93c72e33221ae025969f60L157) [[15]](diffhunk://#diff-bde2d5dbfa308a53395144d54ecc66f60c7665cf2b93c72e33221ae025969f60L180-R177) [[16]](diffhunk://#diff-bde2d5dbfa308a53395144d54ecc66f60c7665cf2b93c72e33221ae025969f60L195) [[17]](diffhunk://#diff-bde2d5dbfa308a53395144d54ecc66f60c7665cf2b93c72e33221ae025969f60L209) [[18]](diffhunk://#diff-bde2d5dbfa308a53395144d54ecc66f60c7665cf2b93c72e33221ae025969f60L272) [[19]](diffhunk://#diff-23e11c7ea6052f84469bc8862a9005dd3dc99302a6edf37426c8ec9552ac42ccL150-L153) [[20]](diffhunk://#diff-23e11c7ea6052f84469bc8862a9005dd3dc99302a6edf37426c8ec9552ac42ccL167)

### ProGuard Rules Update
* Removed the ProGuard rule for keeping the `FormbricksCallback` interface, as it is no longer used.