### PR TITLE
chore: exclude non-business logic from coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,7 +17,13 @@ sonar.sourceEncoding=UTF-8
 
 # Exclusions
 sonar.exclusions=**/test/**/*,**/androidTest/**/*,**/*.js,**/*.json
-sonar.coverage.exclusions=**/test/**/*,**/androidTest/**/*,**/*.js,**/*.json
+sonar.coverage.exclusions=**/test/**/*,**/androidTest/**/*,**/*.js,**/*.json,\
+  **/model/**/*.kt,\
+  **/generated/**/*,\
+  **/*Binding.kt,\
+  **/*BindingImpl.kt,\
+  **/*_Factory.kt,\
+  **/*_MembersInjector.kt
 
 # Debug
 sonar.verbose=true 


### PR DESCRIPTION
This pull request updates the `sonar-project.properties` file to refine the coverage exclusions for SonarQube analysis, ensuring that specific generated and model-related files are excluded from coverage metrics.

The rationale for these exclusions:
**/model/**/*.kt: These are data classes and models that only contain properties and basic serialization. They don't contain business logic that needs testing.
**/generated/**/*: Generated code should not be included in coverage metrics as it's automatically generated and maintained.
**/*Binding.kt, **/*BindingImpl.kt: DataBinding related files that are generated by the Android framework.
**/*_Factory.kt, **/*_MembersInjector.kt: Dependency injection related generated files.

### Updates to SonarQube configuration:

* [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL20-R26): Expanded `sonar.coverage.exclusions` to include additional file patterns for exclusion, such as `**/model/**/*.kt`, `**/generated/**/*`, and several specific file suffixes like `*Binding.kt`, `*BindingImpl.kt`, `*_Factory.kt`, and `*_MembersInjector.kt`. This helps to exclude non-essential or auto-generated files from coverage analysis.