### PR TITLE
chore: exclude non-logic files from coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -23,7 +23,12 @@ sonar.coverage.exclusions=**/test/**/*,**/androidTest/**/*,**/*.js,**/*.json,\
   **/*Binding.kt,\
   **/*BindingImpl.kt,\
   **/*_Factory.kt,\
-  **/*_MembersInjector.kt
+  **/*_MembersInjector.kt,\
+  **/FormbricksAPIError.kt,\
+  **/Logger.kt,\
+  **/Guard.kt,\
+  **/DateExtensions.kt,\
+  **/FormbricksRetrofitBuilder.kt
 
 # Debug
 sonar.verbose=true 


### PR DESCRIPTION
This pull request updates the `sonar-project.properties` file to expand the list of files excluded from SonarQube code coverage analysis. The changes primarily focus on excluding additional utility and API-related files.

### Excluded Files and Explanations

1. **FormbricksAPIError.kt**
   - **Reason:** This is a data-only class (a data class extending `RuntimeException`), with no logic to test. Exception/data holder classes are typically excluded from coverage.

2. **Logger.kt**
   - **Reason:** This is a trivial logging utility that simply wraps Android's `Log` methods. It contains no business logic and is not meaningful to test.

3. **Guard.kt**
   - **Reason:** Contains simple, generic extension functions for null-checking and guard patterns. These are utility functions with minimal logic, often not tested directly.

4. **DateExtensions.kt**
   - **Reason:** Provides extension functions for date formatting and parsing. These are simple utility functions, and unless you have custom date logic, they can be excluded.

5. **FormbricksRetrofitBuilder.kt**
   - **Reason:** This is a glue class for building Retrofit instances. It contains no business logic, just configuration for HTTP clients.


### Updates to SonarQube coverage exclusions:
* Added the following files to the `sonar.coverage.exclusions` list:
  - `**/FormbricksAPIError.kt`
  - `**/Logger.kt`
  - `**/Guard.kt`
  - `**/DateExtensions.kt`
  - `**/FormbricksRetrofitBuilder.kt`