### PR TITLE
chore: revert coverage exclude of FormbricksRetrofitBuilder

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -27,8 +27,7 @@ sonar.coverage.exclusions=**/test/**/*,**/androidTest/**/*,**/*.js,**/*.json,\
   **/FormbricksAPIError.kt,\
   **/Logger.kt,\
   **/Guard.kt,\
-  **/DateExtensions.kt,\
-  **/FormbricksRetrofitBuilder.kt
+  **/DateExtensions.kt
 
 # Debug
 sonar.verbose=true 


### PR DESCRIPTION
This pull request modifies the `sonar-project.properties` file to adjust the code coverage exclusions. The most notable change is the removal of `FormbricksRetrofitBuilder.kt` from the exclusions list.

Code coverage exclusions update:

* [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL30-R30): Removed `FormbricksRetrofitBuilder.kt` from the list of excluded files, indicating it will now be included in code coverage analysis.