### PR TITLE
chore: add test for json helpers

### DIFF
--- a/android/src/androidTest/java/com/formbricks/android/helper/JsonHelperInstrumentedTest.kt
+++ b/android/src/androidTest/java/com/formbricks/android/helper/JsonHelperInstrumentedTest.kt
@@ -1,0 +1,105 @@
+package com.formbricks.android.helper
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.serialization.json.*
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class JsonHelperInstrumentedTest {
+    @Test
+    fun testMapToJsonElement_withPrimitives() {
+        val map = mapOf(
+            "string" to "value",
+            "int" to 1,
+            "double" to 2.5,
+            "bool" to true
+        )
+        val json = mapToJsonElement(map)
+        assertEquals("value", json.jsonObject["string"]?.jsonPrimitive?.content)
+        assertEquals(1, json.jsonObject["int"]?.jsonPrimitive?.int)
+        assertEquals(2.5, json.jsonObject["double"]?.jsonPrimitive?.double ?: 0.0, 0.0)
+        assertEquals(true, json.jsonObject["bool"]?.jsonPrimitive?.boolean)
+    }
+
+    @Test
+    fun testMapToJsonElement_withNestedMap() {
+        val map = mapOf(
+            "outer" to mapOf(
+                "inner" to "inside"
+            )
+        )
+        val json = mapToJsonElement(map)
+        assertEquals("inside", json.jsonObject["outer"]?.jsonObject?.get("inner")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun testMapToJsonElement_withList() {
+        val map = mapOf(
+            "list" to listOf(1, 2, 3)
+        )
+        val json = mapToJsonElement(map)
+        val arr = json.jsonObject["list"] as JsonArray
+        assertEquals(3, arr.size)
+        assertEquals(1, arr[0].jsonPrimitive.int)
+        assertEquals(2, arr[1].jsonPrimitive.int)
+        assertEquals(3, arr[2].jsonPrimitive.int)
+    }
+
+    @Test
+    fun testMapToJsonElement_withNull() {
+        val map = mapOf(
+            "something" to null
+        )
+        val json = mapToJsonElement(map)
+        assertTrue(json.jsonObject["something"] is JsonNull)
+    }
+
+    @Test
+    fun testMapToJsonElement_withListOfMaps() {
+        val map = mapOf(
+            "list" to listOf(
+                mapOf("a" to 1),
+                mapOf("b" to 2)
+            )
+        )
+        val json = mapToJsonElement(map)
+        val arr = json.jsonObject["list"] as JsonArray
+        assertEquals(2, arr.size)
+        assertEquals(1, arr[0].jsonObject["a"]?.jsonPrimitive?.int)
+        assertEquals(2, arr[1].jsonObject["b"]?.jsonPrimitive?.int)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testMapToJsonElement_withUnsupportedType() {
+        val map = mapOf("bad" to Any())
+        mapToJsonElement(map)
+    }
+
+    @Test
+    fun testMapToJsonElementItem_withPrimitives() {
+        assertEquals(JsonPrimitive("hello"), mapToJsonElementItem("hello"))
+        assertEquals(JsonPrimitive(42), mapToJsonElementItem(42))
+        assertEquals(JsonPrimitive(true), mapToJsonElementItem(true))
+    }
+
+    @Test
+    fun testMapToJsonElementItem_withNull() {
+        assertTrue(mapToJsonElementItem(null) is JsonNull)
+    }
+
+    @Test
+    fun testMapToJsonElementItem_withList() {
+        val list = listOf("a", "b")
+        val json = mapToJsonElementItem(list)
+        assertTrue(json is JsonArray)
+        assertEquals("a", (json as JsonArray)[0].jsonPrimitive.content)
+        assertEquals("b", json[1].jsonPrimitive.content)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testMapToJsonElementItem_withUnsupportedType() {
+        mapToJsonElementItem(Any())
+    }
+} 

--- a/android/src/androidTest/java/com/formbricks/android/webview/FormbricksViewModelInstrumentedTest.kt
+++ b/android/src/androidTest/java/com/formbricks/android/webview/FormbricksViewModelInstrumentedTest.kt
@@ -1,0 +1,81 @@
+package com.formbricks.android.webview
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.formbricks.android.Formbricks
+import com.formbricks.android.manager.UserManager
+import com.formbricks.android.model.environment.EnvironmentDataHolder
+import com.formbricks.android.model.environment.EnvironmentResponseData
+import com.formbricks.android.model.environment.EnvironmentData
+import com.formbricks.android.model.environment.Project
+import com.formbricks.android.model.environment.Survey
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FormbricksViewModelInstrumentedTest {
+    @Before
+    fun setup() {
+        // Set up static singletons with minimal values
+        Formbricks.appUrl = "https://test.formbricks.com"
+        Formbricks.environmentId = "env123"
+        Formbricks.language = "en"
+        // Use reflection to set private contactId
+        val contactIdField = UserManager::class.java.getDeclaredField("backingContactId")
+        contactIdField.isAccessible = true
+        contactIdField.set(UserManager, "contact123")
+    }
+
+    @Test
+    fun testGetJson_minimalEnvironment() {
+        // Minimal survey and environment
+        val surveyId = "survey1"
+        val survey = Survey(
+            id = surveyId,
+            name = "Test Survey",
+            triggers = null,
+            recontactDays = null,
+            displayLimit = null,
+            delay = null,
+            displayPercentage = null,
+            displayOption = null,
+            segment = null,
+            styling = null,
+            languages = null
+        )
+        val project = Project(
+            id = "proj1",
+            recontactDays = null,
+            clickOutsideClose = null,
+            darkOverlay = null,
+            placement = null,
+            inAppSurveyBranding = null,
+            styling = null
+        )
+        val envData = EnvironmentData(
+            surveys = listOf(survey),
+            actionClasses = null,
+            project = project
+        )
+        val envResponseData = EnvironmentResponseData(
+            data = envData,
+            expiresAt = null
+        )
+        val envHolder = EnvironmentDataHolder(
+            data = envResponseData,
+            originalResponseMap = mapOf()
+        )
+        val viewModel = FormbricksViewModel()
+        val json = viewModel.javaClass.getDeclaredMethod("getJson", EnvironmentDataHolder::class.java, String::class.java)
+            .apply { isAccessible = true }
+            .invoke(viewModel, envHolder, surveyId) as String
+        // Check that the output JSON string contains expected keys/values
+        assertTrue(json.contains("\"survey\""))
+        assertTrue(json.contains("\"isBrandingEnabled\":true"))
+        assertTrue(json.contains("https://test.formbricks.com"))
+        assertTrue(json.contains("env123"))
+        assertTrue(json.contains("contact123"))
+        assertTrue(json.contains("\"languageCode\":\"default\""))
+    }
+} 

--- a/android/src/androidTest/java/com/formbricks/android/webview/WebAppInterfaceInstrumentedTest.kt
+++ b/android/src/androidTest/java/com/formbricks/android/webview/WebAppInterfaceInstrumentedTest.kt
@@ -1,0 +1,94 @@
+package com.formbricks.android.webview
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.formbricks.android.model.javascript.EventType
+import com.formbricks.android.model.javascript.FileUploadData
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WebAppInterfaceInstrumentedTest {
+    private lateinit var callback: FakeCallback
+    private lateinit var webAppInterface: WebAppInterface
+
+    class FakeCallback : WebAppInterface.WebAppCallback {
+        var closed = false
+        var displayCreated = false
+        var responseCreated = false
+        var filePick: FileUploadData? = null
+        var surveyLibraryLoadError = false
+        override fun onClose() { closed = true }
+        override fun onDisplayCreated() { displayCreated = true }
+        override fun onResponseCreated() { responseCreated = true }
+        override fun onFilePick(data: FileUploadData) { filePick = data }
+        override fun onSurveyLibraryLoadError() { surveyLibraryLoadError = true }
+    }
+
+    @Before
+    fun setup() {
+        callback = FakeCallback()
+        webAppInterface = WebAppInterface(callback)
+    }
+
+    @Test
+    fun testMessage_onClose() {
+        val json = "{\"event\":\"onClose\"}"
+        webAppInterface.message(json)
+        assertTrue(callback.closed)
+    }
+
+    @Test
+    fun testMessage_onDisplayCreated() {
+        val json = "{\"event\":\"onDisplayCreated\"}"
+        webAppInterface.message(json)
+        assertTrue(callback.displayCreated)
+    }
+
+    @Test
+    fun testMessage_onResponseCreated() {
+        val json = "{\"event\":\"onResponseCreated\"}"
+        webAppInterface.message(json)
+        assertTrue(callback.responseCreated)
+    }
+
+    @Test
+    fun testMessage_onFilePick() {
+        val json = "{\"event\":\"onFilePick\",\"fileUploadParams\":{\"allowedFileExtensions\":\"jpg\",\"allowMultipleFiles\":true}}"
+        webAppInterface.message(json)
+        assertNotNull(callback.filePick)
+        assertEquals("jpg", callback.filePick?.fileUploadParams?.allowedFileExtensions)
+        assertEquals(true, callback.filePick?.fileUploadParams?.allowMultipleFiles)
+    }
+
+    @Test
+    fun testMessage_onSurveyLibraryLoadError() {
+        val json = "{\"event\":\"onSurveyLibraryLoadError\"}"
+        webAppInterface.message(json)
+        assertTrue(callback.surveyLibraryLoadError)
+    }
+
+    @Test
+    fun testMessage_invalidJson() {
+        // Should not throw, should not call any callback
+        webAppInterface.message("not a json")
+        assertFalse(callback.closed)
+        assertFalse(callback.displayCreated)
+        assertFalse(callback.responseCreated)
+        assertNull(callback.filePick)
+        assertFalse(callback.surveyLibraryLoadError)
+    }
+
+    @Test
+    fun testMessage_unknownEvent() {
+        val json = "{\"event\":\"unknown_event\"}"
+        webAppInterface.message(json)
+        // Should not call any callback
+        assertFalse(callback.closed)
+        assertFalse(callback.displayCreated)
+        assertFalse(callback.responseCreated)
+        assertNull(callback.filePick)
+        assertFalse(callback.surveyLibraryLoadError)
+    }
+} 


### PR DESCRIPTION
This pull request adds a new test suite for the `JsonHelper` utility in the Android project. The suite includes comprehensive tests to validate the behavior of the `mapToJsonElement` and `mapToJsonElementItem` functions with various input types.

### New Test Suite for `JsonHelper`:

* **Comprehensive Tests for `mapToJsonElement`**:
  - Added tests to verify the function's handling of primitive types, nested maps, lists, null values, and unsupported types.

* **Comprehensive Tests for `mapToJsonElementItem`**:
  - Added tests to verify the function's handling of primitive types, null values, lists, and unsupported types.