### PR TITLE
chore: add more tests to Formbricks Api Service

### DIFF
--- a/android/src/androidTest/java/com/formbricks/android/network/FormbricksApiServiceInstrumentedTest.kt
+++ b/android/src/androidTest/java/com/formbricks/android/network/FormbricksApiServiceInstrumentedTest.kt
@@ -50,6 +50,23 @@ class FormbricksApiServiceInstrumentedTest {
         assertTrue(result.isFailure)
     }
 
+    @Test
+    fun testPostUser_withNullAttributes_handlesErrorGracefully() {
+        val dummyBody = PostUserBody("dummy-user-id", null)
+        val result = apiService.postUser("dummy-environment-id", dummyBody)
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun testInitialize_multipleTimes_noCrash() {
+        try {
+            apiService.initialize("https://example.com", isLoggingEnabled = false)
+            apiService.initialize("https://another-url.com", isLoggingEnabled = true)
+        } catch (e: Exception) {
+            fail("Multiple initializations should not throw: ${e.message}")
+        }
+    }
+
     // Add more integration-style tests as needed, e.g.:
     // - testGetEnvironmentStateObject_withMockServer
     // - testPostUser_withMockServer

--- a/android/src/androidTest/java/com/formbricks/android/network/FormbricksApiServiceInstrumentedTest.kt
+++ b/android/src/androidTest/java/com/formbricks/android/network/FormbricksApiServiceInstrumentedTest.kt
@@ -67,6 +67,14 @@ class FormbricksApiServiceInstrumentedTest {
         }
     }
 
+    @Test
+    fun testGetEnvironmentStateObject_beforeInitialize_returnsFailure() {
+        val uninitializedService = FormbricksApiService()
+        val result = uninitializedService.getEnvironmentStateObject("dummy")
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is UninitializedPropertyAccessException)
+    }
+
     // Add more integration-style tests as needed, e.g.:
     // - testGetEnvironmentStateObject_withMockServer
     // - testPostUser_withMockServer


### PR DESCRIPTION
This pull request adds three new test cases to the `FormbricksApiServiceInstrumentedTest` class to improve the robustness and reliability of the `FormbricksApiService` by covering additional edge cases.

### New test cases added:

* **Error handling for null attributes in `postUser`:**
  - Added `testPostUser_withNullAttributes_handlesErrorGracefully` to ensure the `postUser` method handles cases where user attributes are `null` without crashing.

* **Robustness of multiple initializations:**
  - Added `testInitialize_multipleTimes_noCrash` to verify that calling `initialize` multiple times with different configurations does not result in a crash or exception.

* **Behavior before initialization:**
  - Added `testGetEnvironmentStateObject_beforeInitialize_returnsFailure` to confirm that calling `getEnvironmentStateObject` before initializing the service fails gracefully with an appropriate exception (`UninitializedPropertyAccessException`).