### PR TITLE
fix: types and tests

### DIFF
--- a/android/src/androidTest/java/com/formbricks/android/FormbricksInstrumentedTest.kt
+++ b/android/src/androidTest/java/com/formbricks/android/FormbricksInstrumentedTest.kt
@@ -125,7 +125,7 @@ class FormbricksInstrumentedTest {
         assertNotNull("Should have click_demo_button action class", clickDemoButtonAction)
         
         val triggers = firstSurveyBeforeTrack?.triggers ?: listOf()
-        val matchingTrigger = triggers.firstOrNull { it.actionClass?.id == clickDemoButtonAction?.id }
+        val matchingTrigger = triggers.firstOrNull { it.actionClass?.name == clickDemoButtonAction?.name }
         assertNotNull("Survey should have matching trigger", matchingTrigger)
         
         // Now track the event

--- a/android/src/androidTest/java/com/formbricks/android/manager/SurveyManagerInstrumentedTest.kt
+++ b/android/src/androidTest/java/com/formbricks/android/manager/SurveyManagerInstrumentedTest.kt
@@ -1,7 +1,6 @@
 package com.formbricks.android.manager
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.formbricks.android.Formbricks
 import com.formbricks.android.model.environment.*
 import com.formbricks.android.model.user.Display
 import org.junit.Assert.*
@@ -9,7 +8,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.Date
-import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class SurveyManagerInstrumentedTest {

--- a/android/src/main/java/com/formbricks/android/manager/SurveyManager.kt
+++ b/android/src/main/java/com/formbricks/android/manager/SurveyManager.kt
@@ -7,10 +7,13 @@ import com.formbricks.android.extensions.expiresAt
 import com.formbricks.android.extensions.guard
 import com.formbricks.android.logger.Logger
 import com.formbricks.android.model.environment.EnvironmentDataHolder
+import com.formbricks.android.model.environment.SegmentFilterResource
+import com.formbricks.android.model.environment.SegmentFilterResourceDeserializer
 import com.formbricks.android.model.environment.Survey
 import com.formbricks.android.model.error.SDKError
 import com.formbricks.android.model.user.Display
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -36,6 +39,16 @@ object SurveyManager {
     private val prefManager by lazy { Formbricks.applicationContext.getSharedPreferences(FORMBRICKS_PREFS, Context.MODE_PRIVATE) }
     internal var filteredSurveys: MutableList<Survey> = mutableListOf()
 
+    // 1) Build your Gson once, registering only the SegmentFilterResource adapter:
+    val gson = GsonBuilder()
+        .registerTypeAdapter(
+            SegmentFilterResource::class.java,
+            SegmentFilterResourceDeserializer()
+        )
+        .create()
+
+
+
     private var environmentDataHolderJson: String?
         get() {
             return prefManager.getString(PREF_FORMBRICKS_DATA_HOLDER, "")
@@ -57,7 +70,7 @@ object SurveyManager {
             synchronized(this) {
                 backingEnvironmentDataHolder = environmentDataHolderJson?.let { json ->
                     try {
-                        Gson().fromJson(json, EnvironmentDataHolder::class.java)
+                        gson.fromJson(json, EnvironmentDataHolder::class.java)
                     } catch (e: Exception) {
                         Logger.e(RuntimeException("Unable to retrieve environment data from the local storage."))
                         null

--- a/android/src/main/java/com/formbricks/android/model/environment/ActionClassReference.kt
+++ b/android/src/main/java/com/formbricks/android/model/environment/ActionClassReference.kt
@@ -5,6 +5,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ActionClassReference(
-    @SerializedName("id") val id: String?,
     @SerializedName("name") val name: String?
 )

--- a/android/src/main/java/com/formbricks/android/model/environment/SegmentFilterResourceDeserializer.kt
+++ b/android/src/main/java/com/formbricks/android/model/environment/SegmentFilterResourceDeserializer.kt
@@ -1,0 +1,25 @@
+package com.formbricks.android.model.environment
+
+import com.google.gson.*
+import com.google.gson.reflect.TypeToken
+import java.lang.reflect.Type
+
+class SegmentFilterResourceDeserializer : JsonDeserializer<SegmentFilterResource> {
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext
+    ): SegmentFilterResource {
+        return if (json.isJsonArray) {
+            // JSON is an array → treat it as a Group
+            val listType = object : TypeToken<List<SegmentFilter>>() {}.type
+            val filters: List<SegmentFilter> = context.deserialize(json, listType)
+            SegmentFilterResource.Group(filters)
+        } else {
+            // JSON is an object → treat it as a Primitive
+            val prim: SegmentPrimitiveFilter =
+                context.deserialize(json, SegmentPrimitiveFilter::class.java)
+            SegmentFilterResource.Primitive(prim)
+        }
+    }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,7 +25,7 @@ sonar.coverage.exclusions=**/test/**/*,**/androidTest/**/*,**/*.js,**/*.json,\
   **/*_Factory.kt,\
   **/*_MembersInjector.kt,\
   **/FormbricksAPIError.kt,\
-  **/Network/FormbricksService.kt,\
+  **/network/FormbricksService.kt,\
   **/Logger.kt,\
   **/Guard.kt,\
   **/DateExtensions.kt,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,6 +25,7 @@ sonar.coverage.exclusions=**/test/**/*,**/androidTest/**/*,**/*.js,**/*.json,\
   **/*_Factory.kt,\
   **/*_MembersInjector.kt,\
   **/FormbricksAPIError.kt,\
+  **/Network/FormbricksService.kt,\
   **/Logger.kt,\
   **/Guard.kt,\
   **/DateExtensions.kt,\


### PR DESCRIPTION
This pull request introduces several changes to improve the functionality and maintainability of the Formbricks Android SDK. The most important updates include replacing the use of `id` with `name` in `ActionClassReference`, adding a custom deserializer for `SegmentFilterResource`, and updating the Gson configuration in `SurveyManager`. Additionally, minor cleanup and configuration updates were made.

### Functional Improvements:
* **Switch from `id` to `name` for `ActionClassReference`:** Updated `ActionClassReference` to use `name` instead of `id`, and adjusted related logic in `FormbricksInstrumentedTest` to reflect this change. (`[[1]](diffhunk://#diff-17f9055fd2a7b5b3d60e0cfbdc2bb867b9dc7d837fedbcdbe016425973c92fe7L8)`, `[[2]](diffhunk://#diff-d8025fc041721bf9548c55167b39fa47fc3ba369cdd762cfc3727d5e98692e48L128-R128)`)

* **Custom Gson deserializer for `SegmentFilterResource`:** Added `SegmentFilterResourceDeserializer` to handle both array and object JSON formats for `SegmentFilterResource`. (`[android/src/main/java/com/formbricks/android/model/environment/SegmentFilterResourceDeserializer.ktR1-R25](diffhunk://#diff-2f2cce680af0452e17e17d7821df2443867e87ccedd708117869d35cef84fe27R1-R25)`)

* **Gson configuration in `SurveyManager`:** Introduced a centralized Gson instance in `SurveyManager` with the custom deserializer registered, replacing the default Gson usage. (`[[1]](diffhunk://#diff-bde2d5dbfa308a53395144d54ecc66f60c7665cf2b93c72e33221ae025969f60R42-R51)`, `[[2]](diffhunk://#diff-bde2d5dbfa308a53395144d54ecc66f60c7665cf2b93c72e33221ae025969f60L60-R73)`)

### Cleanup and Configuration:
* **Removed unused imports:** Cleaned up unused imports in `SurveyManagerInstrumentedTest` to improve readability. (`[android/src/androidTest/java/com/formbricks/android/manager/SurveyManagerInstrumentedTest.ktL4-L12](diffhunk://#diff-cde270f86fb07a8e127a02282a62efa7c15d47729e3530fafd3edd6784d101aaL4-L12)`)

* **Updated sonar exclusions:** Added `Network/FormbricksService.kt` to the list of files excluded from SonarQube coverage analysis. (`[sonar-project.propertiesR28](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cR28)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved support for advanced survey filtering by enabling polymorphic deserialization of segment filters.
- **Bug Fixes**
	- Updated survey action matching to use action names instead of IDs for better reliability.
- **Chores**
	- Excluded a specific network service file from code coverage analysis.
	- Removed unused imports in test files.
- **Refactor**
	- Simplified action class references by removing unused ID fields and retaining only the name property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->