### PR TITLE
chore: change version number for release

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 // Import JaCoCo configuration
 // apply(from = "../jacoco.gradle.kts")
 
-version = "1.1.0"
+version = "1.0.2"
 val groupId = "com.formbricks"
 val artifactId = "android"
 


### PR DESCRIPTION
This pull request includes a small change to the `android/build.gradle.kts` file. The change updates the `version` property from `1.1.0` to `1.0.2` to reflect a version rollback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the app version from 1.1.0 to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->