### PR TITLE
fix: for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-to-maven-central.yml
+++ b/.github/workflows/publish-to-maven-central.yml
@@ -1,6 +1,8 @@
 # .github/workflows/publish-to-maven-central.yml
 
 name: Publish to Maven Central
+permissions:
+  contents: read
 on:
   release:
     types: [released]


### PR DESCRIPTION
Potential fix for [https://github.com/formbricks/android/security/code-scanning/1](https://github.com/formbricks/android/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves publishing to Maven Central, it does not appear to require write access to the repository contents. Therefore, we will set `contents: read` as the minimal permission. If additional permissions are required for specific operations, they can be added later.

The `permissions` block will be added at the workflow level (root) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions for publishing to Maven Central to enhance security. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->