### PR TITLE
chore: remove unused query parameter from surveys package call

### DIFF
--- a/android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt
+++ b/android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt
@@ -99,7 +99,7 @@ class FormbricksViewModel : ViewModel() {
               observer.observe(document.body, { childList: true, subtree: true });
 
                 const script = document.createElement("script");
-                script.src = "${Formbricks.appUrl}/js/surveys.umd.cjs?randQuery=123445";
+                script.src = "${Formbricks.appUrl}/js/surveys.umd.cjs";
                 script.async = true;
                 script.onload = () => loadSurvey();
                 script.onerror = (error) => {


### PR DESCRIPTION
This pull request includes a minor update to the `FormbricksViewModel` class in the `Formbricks` Android project. The change removes a hardcoded query parameter from the URL used to load the survey script.

* [`android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt`](diffhunk://#diff-85fa7f03b6204961ebdbe80b0d21e6b78363baac564e92b6905bb27e9a595680L102-R102): Removed the `randQuery=123445` query parameter from the `script.src` URL to simplify the script loading process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loading of the external survey script by removing an unnecessary query parameter from the URL, ensuring a cleaner and more reliable script loading process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->