### PR TITLE
fix: blackduck issues

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     kotlin("android")
     kotlin("kapt")
     kotlin("plugin.serialization") version "2.1.0"
-    id("org.jetbrains.dokka") version "1.9.10"
+    id("org.jetbrains.dokka") version "1.9.20"
     id("jacoco")
     id("com.vanniktech.maven.publish") version "0.31.0"
     id("org.sonarqube") version "4.4.1.3373"

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -11,9 +11,6 @@ plugins {
     id("org.sonarqube") version "4.4.1.3373"
 }
 
-// Import JaCoCo configuration
-// apply(from = "../jacoco.gradle.kts")
-
 version = "1.0.2"
 val groupId = "com.formbricks"
 val artifactId = "android"
@@ -86,7 +83,6 @@ dependencies {
     implementation(libs.material)
 
     implementation(libs.kotlinx.serialization.json)
-    implementation(libs.androidx.legacy.support.v4)
     implementation(libs.androidx.lifecycle.livedata.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.fragment.ktx)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,13 +14,12 @@ androidx-annotation = "1.9.1"
 
 kotlinx-serialization-json = "1.8.0"
 
-retrofit = "2.11.0"
-okhttp3 = "4.11.0"
-gson = "2.10.1"
-legacySupportV4 = "1.0.0"
-lifecycleLivedataKtx = "2.8.7"
-lifecycleViewmodelKtx = "2.8.7"
-fragmentKtx = "1.8.6"
+retrofit = "3.0.0"
+okhttp3 = "4.12.0"
+gson = "2.13.1"
+lifecycleLivedataKtx = "2.9.0"
+lifecycleViewmodelKtx = "2.9.0"
+fragmentKtx = "1.8.7"
 databindingCommon = "8.9.2"
 
 [libraries]
@@ -39,7 +38,6 @@ okhttp3-logging-interceptor = { module = "com.squareup.okhttp3:logging-intercept
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-androidx-legacy-support-v4 = { group = "androidx.legacy", name = "legacy-support-v4", version.ref = "legacySupportV4" }
 androidx-lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycleLivedataKtx" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
 androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "fragmentKtx" }


### PR DESCRIPTION
This pull request updates dependencies and plugins in the Android project to ensure compatibility and improve maintainability. Key changes include upgrading the Dokka plugin, updating various library versions, and removing unused dependencies.

### Plugin Updates:
* Updated `org.jetbrains.dokka` plugin to version `1.9.20` in `android/build.gradle.kts`.

### Dependency Updates:
* Removed the unused `androidx.legacy.support.v4` dependency from `android/build.gradle.kts`.
* Updated versions of several dependencies in `gradle/libs.versions.toml`:
  - Upgraded `retrofit` to `3.0.0`.
  - Upgraded `okhttp3` to `4.12.0`.
  - Upgraded `gson` to `2.13.1`.
  - Updated `lifecycle-livedata-ktx` to `2.9.0` and `lifecycle-viewmodel-ktx` to `2.9.0`.
  - Updated `fragment-ktx` to `1.8.7`.

### Dependency Cleanup:
* Removed the `androidx-legacy-support-v4` entry from `gradle/libs.versions.toml` as it is no longer used.

With the removal of the `androidx-legacy-support-v4` dependency, the SDK no longer relies on deprecated `android.support.*` libraries. This change does not reduce device compatibility for consuming apps.

The minimum supported Android version remains API 21 (Android 5.0, Lollipop), which is fully compatible with AndroidX at runtime. Consumers of the SDK can still configure minSdkVersion = 21 in their apps without any issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated several library dependencies to their latest versions, including Retrofit, OkHttp, Gson, and AndroidX Lifecycle components.
  - Upgraded the documentation plugin to a newer version.
  - Removed the legacy Android support library from the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->