### PR TITLE
fix: fixes responses stuck error

### DIFF
--- a/android/src/main/java/com/formbricks/android/webview/FormbricksFragment.kt
+++ b/android/src/main/java/com/formbricks/android/webview/FormbricksFragment.kt
@@ -150,11 +150,6 @@ class FormbricksFragment : BottomSheetDialogFragment() {
             it.webChromeClient = object : WebChromeClient() {
                 override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
                     consoleMessage?.let { cm ->
-                        if (cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) {
-                            val error = SDKError.surveyDisplayFetchError
-                            Logger.e(error)
-                            dismiss()
-                        }
                         val log = "[CONSOLE:${cm.messageLevel()}] \"${cm.message()}\", source: ${cm.sourceId()} (${cm.lineNumber()})"
                         Logger.d(log)
                     }

--- a/android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt
+++ b/android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt
@@ -51,11 +51,17 @@ class FormbricksViewModel : ViewModel() {
                 function onResponseCreated() {
                     FormbricksJavascript.message(JSON.stringify({ event: "onResponseCreated" }));
                 };
+                
+                let setResponseFinished = null;
+                function getSetIsResponseSendingFinished(callback) {
+                    setResponseFinished = callback;
+                }                
                   
                 function loadSurvey() {
                     const options = JSON.parse(json);
                     const surveyProps = {
                         ...options,
+                        getSetIsResponseSendingFinished,
                         onDisplayCreated,
                         onResponseCreated,
                         onClose,
@@ -97,7 +103,6 @@ class FormbricksViewModel : ViewModel() {
               });
         
               observer.observe(document.body, { childList: true, subtree: true });
-
                 const script = document.createElement("script");
                 script.src = "${Formbricks.appUrl}/js/surveys.umd.cjs";
                 script.async = true;


### PR DESCRIPTION
This pull request makes improvements to the error handling in `FormbricksFragment` and enhances the survey response handling in `FormbricksViewModel`. The most important changes include removing error dismissal behavior in the WebView console and adding functionality to track survey response completion.

### Error handling improvements:

* [`android/src/main/java/com/formbricks/android/webview/FormbricksFragment.kt`](diffhunk://#diff-3a8413758cf1cd9c6e6eacb10e0af4a360d5925ebcc4aa9edc1b82889a11344bL153-L157): Removed the code that dismissed the fragment on WebView console errors, allowing the app to log errors without interrupting the user experience.

### Survey response handling enhancements:

* [`android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt`](diffhunk://#diff-85fa7f03b6204961ebdbe80b0d21e6b78363baac564e92b6905bb27e9a595680R55-R64): Added the `getSetIsResponseSendingFinished` function to enable tracking when survey responses have finished sending. This function is passed as a property (`getSetIsResponseSendingFinished`) to the survey options.
* [`android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt`](diffhunk://#diff-85fa7f03b6204961ebdbe80b0d21e6b78363baac564e92b6905bb27e9a595680L100): Removed an unnecessary blank line near the script injection code for better readability.