### PR TITLE
fix: blocks http requests

### DIFF
--- a/android/src/androidTest/java/com/formbricks/android/FormbricksInstrumentedTest.kt
+++ b/android/src/androidTest/java/com/formbricks/android/FormbricksInstrumentedTest.kt
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit
 class FormbricksInstrumentedTest {
 
     private val environmentId = "environmentId"
-    private val appUrl = "http://appUrl"
+    private val appUrl = "https://example.com"
     private val userId = "6CCCE716-6783-4D0F-8344-9C7DFA43D8F7"
     private val surveyID = "cm6ovw6j7000gsf0kduf4oo4i"
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,4 +3,5 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="35" />
+    <application android:networkSecurityConfig="@xml/network_security_config" />
 </manifest>

--- a/android/src/main/java/com/formbricks/android/Formbricks.kt
+++ b/android/src/main/java/com/formbricks/android/Formbricks.kt
@@ -52,6 +52,13 @@ object Formbricks {
             return
         }
 
+        // Validate HTTPS URL
+        if (!config.appUrl.startsWith("https://", ignoreCase = true)) {
+            val error = RuntimeException("Only HTTPS URLs are allowed for security reasons. HTTP URLs are not permitted. Provided URL: ${config.appUrl}")
+            Logger.e(error)
+            return
+        }
+
         applicationContext = context
 
         appUrl = config.appUrl

--- a/android/src/main/java/com/formbricks/android/network/FormbricksApiService.kt
+++ b/android/src/main/java/com/formbricks/android/network/FormbricksApiService.kt
@@ -15,8 +15,7 @@ import retrofit2.Call
 import retrofit2.Retrofit
 
 open class FormbricksApiService {
-
-    private lateinit var retrofit: Retrofit
+    private var retrofit: Retrofit? = null
 
     fun initialize(appUrl: String, isLoggingEnabled: Boolean) {
         val builder = FormbricksRetrofitBuilder(appUrl, isLoggingEnabled).getBuilder()
@@ -26,14 +25,15 @@ open class FormbricksApiService {
             // Builder returned null due to HTTP URL - log error and skip initialization
             val error = RuntimeException("Failed to initialize API service due to invalid URL configuration. Only HTTPS URLs are allowed.")
             Logger.e(error)
-            // Don't initialize retrofit - it will remain uninitialized and API calls will fail gracefully
+            retrofit = null
         }
     }
 
     open fun getEnvironmentStateObject(environmentId: String): Result<EnvironmentDataHolder> {
         return try {
+            val retrofitInstance = retrofit ?: return Result.failure(RuntimeException("API service not initialized due to invalid URL"))
             val result = execute {
-                retrofit.create(FormbricksService::class.java)
+                retrofitInstance.create(FormbricksService::class.java)
                     .getEnvironmentState(environmentId)
             }
             val json = Json { ignoreUnknownKeys = true }
@@ -48,8 +48,9 @@ open class FormbricksApiService {
     }
 
     open fun postUser(environmentId: String, body: PostUserBody): Result<UserResponse> {
+        val retrofitInstance = retrofit ?: return Result.failure(RuntimeException("API service not initialized due to invalid URL"))
         return execute {
-            retrofit.create(FormbricksService::class.java)
+            retrofitInstance.create(FormbricksService::class.java)
                 .postUser(environmentId, body)
         }
     }

--- a/android/src/main/java/com/formbricks/android/network/FormbricksApiService.kt
+++ b/android/src/main/java/com/formbricks/android/network/FormbricksApiService.kt
@@ -2,6 +2,7 @@ package com.formbricks.android.network
 
 import com.formbricks.android.api.error.FormbricksAPIError
 import com.formbricks.android.helper.mapToJsonElement
+import com.formbricks.android.logger.Logger
 import com.formbricks.android.model.environment.EnvironmentDataHolder
 import com.formbricks.android.model.environment.EnvironmentResponse
 import com.formbricks.android.model.user.PostUserBody
@@ -18,9 +19,15 @@ open class FormbricksApiService {
     private lateinit var retrofit: Retrofit
 
     fun initialize(appUrl: String, isLoggingEnabled: Boolean) {
-        retrofit = FormbricksRetrofitBuilder(appUrl, isLoggingEnabled)
-            .getBuilder()
-            .build()
+        val builder = FormbricksRetrofitBuilder(appUrl, isLoggingEnabled).getBuilder()
+        if (builder != null) {
+            retrofit = builder.build()
+        } else {
+            // Builder returned null due to HTTP URL - log error and skip initialization
+            val error = RuntimeException("Failed to initialize API service due to invalid URL configuration. Only HTTPS URLs are allowed.")
+            Logger.e(error)
+            // Don't initialize retrofit - it will remain uninitialized and API calls will fail gracefully
+        }
     }
 
     open fun getEnvironmentStateObject(environmentId: String): Result<EnvironmentDataHolder> {

--- a/android/src/main/java/com/formbricks/android/network/FormbricksRetrofitBuilder.kt
+++ b/android/src/main/java/com/formbricks/android/network/FormbricksRetrofitBuilder.kt
@@ -1,18 +1,30 @@
 package com.formbricks.android.network
 
+import com.formbricks.android.logger.Logger
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.Response
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 class FormbricksRetrofitBuilder(private val baseUrl: String, private val loggingEnabled: Boolean) {
+    fun getBuilder(): Retrofit.Builder? {
+        // Validate base URL is HTTPS
+        if (!baseUrl.startsWith("https://", ignoreCase = true)) {
+            val error = RuntimeException("Only HTTPS URLs are allowed. HTTP URLs are not permitted for security reasons. Provided URL: $baseUrl")
+            Logger.e(error)
+            return null
+        }
 
-    fun getBuilder(): Retrofit.Builder {
         val clientBuilder = OkHttpClient.Builder()
             .connectTimeout(CONNECT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
             .readTimeout(READ_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
             .followSslRedirects(true)
+            .addInterceptor(HttpsOnlyInterceptor())
+        
         if (loggingEnabled) {
             val logging = HttpLoggingInterceptor()
             logging.setLevel(HttpLoggingInterceptor.Level.BODY)
@@ -23,6 +35,25 @@ class FormbricksRetrofitBuilder(private val baseUrl: String, private val logging
             .baseUrl(baseUrl)
             .addConverterFactory(GsonConverterFactory.create())
             .client(clientBuilder.build())
+    }
+
+    /**
+     * Interceptor that ensures all requests use HTTPS protocol
+     */
+    private class HttpsOnlyInterceptor : Interceptor {
+        @Throws(IOException::class)
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val request = chain.request()
+            val url = request.url
+            
+            if (!url.isHttps) {
+                val error = RuntimeException("HTTP request blocked. Only HTTPS requests are allowed. Attempted URL: $url")
+                Logger.e(error)
+                throw IOException("HTTP request blocked. Only HTTPS requests are allowed. Attempted URL: $url")
+            }
+            
+            return chain.proceed(request)
+        }
     }
 
     companion object {

--- a/android/src/main/res/xml/network_security_config.xml
+++ b/android/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">*</domain>
+    </domain-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system"/>
+        </trust-anchors>
+    </base-config>
+</network-security-config> 

--- a/android/src/main/res/xml/network_security_config.xml
+++ b/android/src/main/res/xml/network_security_config.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="false">
-        <domain includeSubdomains="true">*</domain>
-    </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system"/>
         </trust-anchors>
     </base-config>
-</network-security-config> 
+</network-security-config>


### PR DESCRIPTION
This pull request introduces changes to enforce HTTPS usage throughout the Android application for improved security. Key updates include validation of URLs, blocking HTTP requests, and configuring the app to disallow cleartext traffic.

### HTTPS Enforcement

* [`android/src/androidTest/java/com/formbricks/android/FormbricksInstrumentedTest.kt`](diffhunk://#diff-d8025fc041721bf9548c55167b39fa47fc3ba369cdd762cfc3727d5e98692e48L32-R32): Updated `appUrl` to use `https://example.com` instead of `http://appUrl` to comply with HTTPS requirements.
* [`android/src/main/java/com/formbricks/android/Formbricks.kt`](diffhunk://#diff-82c6e97a2d17fd4a1ad9d7d6189b0f8bcb6ed3b122e085bbe02ec8cdbbe60376R55-R61): Added validation to ensure `appUrl` starts with "https://". Logs an error and prevents initialization if the URL is invalid.
* [`android/src/main/java/com/formbricks/android/network/FormbricksRetrofitBuilder.kt`](diffhunk://#diff-1965b6700339759d6b2f9510641b8cb5bfb9c2a2a8979f04618f038f1891121fR3-R27): Introduced HTTPS validation for `baseUrl` in `getBuilder()`. Returns `null` and logs an error if the URL is not HTTPS. Added `HttpsOnlyInterceptor` to block HTTP requests. [[1]](diffhunk://#diff-1965b6700339759d6b2f9510641b8cb5bfb9c2a2a8979f04618f038f1891121fR3-R27) [[2]](diffhunk://#diff-1965b6700339759d6b2f9510641b8cb5bfb9c2a2a8979f04618f038f1891121fR40-R58)

### Cleartext Traffic Restriction

* [`android/src/main/AndroidManifest.xml`](diffhunk://#diff-93083d0574bec8be4b25f798b65dd82a612412c23a79dc9bdfdfb4a6b7ab37a3R6): Configured the application to use `network_security_config` for restricting cleartext traffic.
* [`android/src/main/res/xml/network_security_config.xml`](diffhunk://#diff-3139724d1bce76e91205c7f275a151c9fcb71195939e0fadb65aadd087da1267R1-R11): Added a network security configuration file to disallow cleartext traffic and enforce HTTPS for all domains.

### Logging Improvements

* [`android/src/main/java/com/formbricks/android/network/FormbricksApiService.kt`](diffhunk://#diff-7c4177cd0009984a0f62b8057ebbdee4635413f35e4458964711b372a8a6f3f2R5): Integrated `Logger` to log errors when URL validation fails during API service initialization. [[1]](diffhunk://#diff-7c4177cd0009984a0f62b8057ebbdee4635413f35e4458964711b372a8a6f3f2R5) [[2]](diffhunk://#diff-7c4177cd0009984a0f62b8057ebbdee4635413f35e4458964711b372a8a6f3f2L21-R30)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enforced HTTPS-only connections throughout the app for improved security.
	- Added network security configuration to block all non-HTTPS (cleartext) traffic.

- **Bug Fixes**
	- Improved error handling and logging when an insecure (non-HTTPS) URL is provided, preventing SDK initialization with invalid URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->