### PR TITLE
fix: branding text

### DIFF
--- a/android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt
+++ b/android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt
@@ -123,7 +123,7 @@ class FormbricksViewModel : ViewModel() {
     private fun getJson(environmentDataHolder: EnvironmentDataHolder, surveyId: String): String {
         val jsonObject = JsonObject()
         environmentDataHolder.getSurveyJson(surveyId).let { jsonObject.add("survey", it) }
-        jsonObject.addProperty("isBrandingEnabled", true)
+        jsonObject.addProperty("isBrandingEnabled", environmentDataHolder.data?.data?.project?.inAppSurveyBranding ?: true)
         jsonObject.addProperty("appUrl", Formbricks.appUrl)
         jsonObject.addProperty("environmentId", Formbricks.environmentId)
         jsonObject.addProperty("contactId", UserManager.contactId)


### PR DESCRIPTION
This pull request introduces a dynamic approach to setting the `isBrandingEnabled` property in the `FormbricksViewModel` class, replacing the previous hardcoded value with a value derived from the `EnvironmentDataHolder`.

Key change:

* [`android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt`](diffhunk://#diff-85fa7f03b6204961ebdbe80b0d21e6b78363baac564e92b6905bb27e9a595680L126-R126): Updated the `getJson` method to set the `isBrandingEnabled` property based on the `inAppSurveyBranding` value from `EnvironmentDataHolder`. If the value is null, it defaults to `true`.