### PR TITLE
chore: bumps sdk version

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     id("org.sonarqube") version "4.4.1.3373"
 }
 
-version = "1.1.0"
+version = "1.2.0"
 val groupId = "com.formbricks"
 val artifactId = "android"
 


### PR DESCRIPTION
bumps the sdk version to `1.2.0`