### PR TITLE
fix(security): base64-encode survey WebView payload to prevent script injection (ENG-1813)

### DIFF
--- a/android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt
+++ b/android/src/main/java/com/formbricks/android/webview/FormbricksViewModel.kt
@@ -1,5 +1,6 @@
 package com.formbricks.android.webview
 
+import android.util.Base64
 import android.webkit.WebView
 import androidx.databinding.BindingAdapter
 import androidx.lifecycle.MutableLiveData
@@ -39,7 +40,10 @@ class FormbricksViewModel : ViewModel() {
             </body>
 
             <script type="text/javascript">
-                const json = `{{WEBVIEW_DATA}}`;
+                // {{WEBVIEW_DATA}} is a base64-encoded JSON string (see loadHtml). Decoding
+                // it here means the survey payload is never parsed as JS source, so survey
+                // content cannot break out of a string literal and execute as code.
+                const json = new TextDecoder().decode(Uint8Array.from(atob("{{WEBVIEW_DATA}}"), c => c.charCodeAt(0)));
 
                 function onClose() {
                     FormbricksJavascript.message(JSON.stringify({ event: "onClose" }));
@@ -117,7 +121,12 @@ class FormbricksViewModel : ViewModel() {
     fun loadHtml(surveyId: String) {
         val workspace = SurveyManager.workspaceDataHolder.guard { return }
         val json = getJson(workspace, surveyId)
-        val htmlString = htmlTemplate.replace("{{WEBVIEW_DATA}}", json)
+        // Base64-encode the payload before embedding it in the HTML. Base64 output is
+        // limited to [A-Za-z0-9+/=], so survey content can no longer contain characters
+        // (backticks, `${...}`, quotes, "</script>") that would break out of the
+        // surrounding JS string and execute. The WebView decodes it back to JSON.
+        val encoded = Base64.encodeToString(json.toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
+        val htmlString = htmlTemplate.replace("{{WEBVIEW_DATA}}", encoded)
         html.postValue(htmlString)
     }
 
@@ -164,13 +173,17 @@ class FormbricksViewModel : ViewModel() {
             workspaceDataHolder.getSettingsStylingJson()?.let { jsonObject.add("styling", it) }
         }
 
+        // Return valid JSON as-is. It is base64-encoded before being embedded in the
+        // HTML (see loadHtml), so no character-level escaping is needed here (the old
+        // #->%23 and \"->' workarounds corrupted survey text and are no longer required).
         return jsonObject.toString()
-            .replace("#", "%23") // Hex color code's # breaks the JSON
-            .replace("\\\"","'") // " is replaced to ' in the html codes in the JSON
     }
 }
 
 @BindingAdapter("htmlText")
 fun WebView.setHtmlText(htmlString: String?) {
-    loadData(htmlString ?: "", "text/html", "UTF-8")
+    // loadDataWithBaseURL (null base URL) loads the document verbatim, without the
+    // URL-decoding that loadData applies to its data: URL. That keeps the base64-encoded
+    // survey payload (which may contain +, / and =) intact. Mirrors iOS's baseURL: nil.
+    loadDataWithBaseURL(null, htmlString ?: "", "text/html", "UTF-8", null)
 }


### PR DESCRIPTION
## What & why

**ENG-1813 — script injection via the survey WebView payload.**

The survey payload was spliced into a JavaScript **template literal** in the WebView HTML:

```js
const json = `{{WEBVIEW_DATA}}`;   // {{WEBVIEW_DATA}} = raw survey JSON
```

Survey content is server/admin-authored (headlines, subheaders, choice labels, styling, an HTML question type…). A value containing a backtick — or `${…}`, which a template literal evaluates eagerly — breaks out of the string and runs as arbitrary JS in the WebView, which also holds the `FormbricksJavascript` bridge. This is the Android counterpart of the iOS issue (formbricks/ios#51).

The existing `#`→`%23` and `\"`→`'` replacements were partial workarounds for the same class of problem: they did **not** stop backtick/`${}` breakout, and they corrupted legitimate survey content (every `"` became `'`, and hex colors like `#FF0000` were percent-mangled).

## Fix

Mirror the iOS remediation — never let survey content be parsed as JS source:

- **Base64-encode** the payload in Kotlin (`Base64.NO_WRAP`) and decode it in the WebView via `atob` + `TextDecoder`, then `JSON.parse`. Base64 output is `[A-Za-z0-9+/=]` only, so backticks, `${…}`, quotes and `</script>` can no longer appear in the string and break out.
- **Removed** the `#`→`%23` and `\"`→`'` workarounds — unnecessary once base64'd, and they were corrupting valid survey text (bonus data-integrity fix).
- **Switched the single `loadData` call to `loadDataWithBaseURL(null, …)`** so the base64 (which may contain `+`, `/`, `=`) isn't mangled by `loadData`'s data:-URL percent-decoding. This is the analogue of iOS's `loadHTMLString(_, baseURL: nil)`.

## Verification

- `./gradlew :android:compileReleaseKotlin` — passes.
- Existing `FormbricksViewModelInstrumentedTest` (`getJson`) is unaffected — its assertions don't depend on the removed workarounds.
- Published via `publishToMavenLocal` and smoke-tested in a host app — surveys render correctly.

## Notes / scope

- No automated regression test yet: the SDK's tests are all instrumented (need an emulator). Tracked as a follow-up — the intended guard feeds hostile content (backtick / `${}` / `</script>`) through payload generation and asserts it appears only inside the base64 blob and round-trips intact.
- Part of a cross-SDK sweep of the iOS survey-WebView findings. iOS: formbricks/ios#51. React Native equivalent: formbricks/react-native#72. Flutter was already safe. TLS (MITM), WebView-debug-in-release, and external-URL-scheme checks were also audited on Android and are already safe.
