### PR TITLE
chore: bump to 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.formbricks:android:2.0.0") // replace with latest version
+    implementation("com.formbricks:android:2.1.0") // replace with latest version
 }
 ```
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     id("org.sonarqube") version "4.4.1.3373"
 }
 
-version = "2.0.0"
+version = "2.1.0"
 val groupId = "com.formbricks"
 val artifactId = "android"
 

--- a/android/src/main/java/com/formbricks/android/webview/WebAppInterface.kt
+++ b/android/src/main/java/com/formbricks/android/webview/WebAppInterface.kt
@@ -14,7 +14,13 @@ class WebAppInterface(private val callback: WebAppCallback?) {
         fun onClose()
         fun onDisplayCreated()
         fun onResponseCreated()
-        fun onFinished()
+
+        /**
+         * Defaulted rather than abstract: [WebAppCallback] is public, so adding an abstract
+         * member would stop any existing implementor from compiling. Only the SDK implements
+         * this today, but that would make an additive change a breaking one.
+         */
+        fun onFinished() {}
         fun onFilePick(data: FileUploadData)
         fun onSurveyLibraryLoadError()
     }

--- a/android/src/main/java/com/formbricks/android/webview/WebAppInterface.kt
+++ b/android/src/main/java/com/formbricks/android/webview/WebAppInterface.kt
@@ -20,7 +20,10 @@ class WebAppInterface(private val callback: WebAppCallback?) {
          * member would stop any existing implementor from compiling. Only the SDK implements
          * this today, but that would make an additive change a breaking one.
          */
-        fun onFinished() {}
+        fun onFinished() {
+            // Intentionally empty. The default exists so implementors that predate this
+            // callback keep compiling; FormbricksFragment overrides it to do the real work.
+        }
         fun onFilePick(data: FileUploadData)
         fun onSurveyLibraryLoadError()
     }


### PR DESCRIPTION
Release prep for [#56](https://github.com/formbricks/android/pull/56). Two commits.

> [!IMPORTANT]
> The first commit is **required for 2.1.0 to be a correct version number**. Please read that section before cutting the release.

---

## 1. `fix`: default `onFinished()` so `WebAppCallback` stays source-compatible

This was pushed to #56 but **did not make it into the merge** — the merge queue had already snapshotted the branch at `02b93d9`, and the squash commit does not contain it. So it is on this PR instead.

`WebAppInterface.WebAppCallback` is declared with no visibility modifier, which in Kotlin means **public**:

```kotlin
class WebAppInterface(private val callback: WebAppCallback?) {
    interface WebAppCallback { ... }
}
```

#56 added an **abstract** `onFinished()` to it. Adding an abstract member to a public interface stops any existing implementor from compiling — which under semver makes the release **breaking**, i.e. 3.0.0 rather than 2.1.0.

In practice nobody implements it: the SDK constructs `WebAppInterface` itself in `FormbricksFragment`, and the interface appears nowhere in the README. So cutting a major would be pointless churn. Giving the method a default body removes the dilemma instead of arguing about it:

```kotlin
fun onFinished() {}
```

Now the change is genuinely additive and 2.1.0 is correct.

> [!NOTE]
> Nothing on `main` is broken today — an abstract member is valid Kotlin and the SDK compiles and runs fine. This is purely about the version number being honest, so it is release-blocking rather than urgent.

## 2. `chore`: bump to 2.1.0

- `android/build.gradle.kts`: `version = "2.0.0"` → `"2.1.0"`
- `README.md`: the install snippet that names a concrete version

---

## Why minor, not patch

**It adds a feature.** Survey-interaction segment filters ("have seen X", "have completed X", …) did not work on Android at all before — the SDK kept using the segment list from app launch, so "completed survey A → show survey B" never fired in the same session.

**It changes behaviour for apps that upgrade, whether or not they use the feature.** The user-state sync was only ever armed after a successful sync, so a launch that found a still-valid cached state scheduled nothing and segments stayed frozen for the whole process. It is now also armed from the warm-cache path — which means **periodic `POST /user` traffic that wasn't there before**. That is the main rollout consideration, and it's why patch would be the wrong signal.

Workspaces using interaction targeting also get an extra `/user` call after a display, response or finish, gated per survey and per event and debounced so a burst costs one request.

**It also carries a crash fix** — [#43](https://github.com/formbricks/android/issues/43), `IllegalStateException: FragmentManager has been destroyed`. On its own that would be a patch, but it ships alongside the feature.

## Verification

`compileDebugKotlin` and `compileDebugAndroidTestKotlin` both pass.

> [!WARNING]
> The 19 instrumented tests added in #56 have **still never been run** — no emulator or device has been available. They compile, which is not the same as passing. Worth running before the release goes out; happy to do it if an emulator can be started.
